### PR TITLE
test: port operation tests

### DIFF
--- a/src/interface/Vault.sol
+++ b/src/interface/Vault.sol
@@ -40,7 +40,7 @@ interface IVault is IERC20 {
         string memory name,
         string memory symbol,
         address guardian,
-        address management 
+        address management
     ) external;
 
     function addStrategy(
@@ -123,6 +123,8 @@ interface IVault is IERC20 {
      * external dependency.
      */
     function revokeStrategy() external;
+
+    function updateStrategyDebtRatio(address strategy, uint256 debtRatio) external;
 
     /**
      * View the governance address of the Vault to assert privileged functions

--- a/src/test/Strategy.t.sol
+++ b/src/test/Strategy.t.sol
@@ -12,12 +12,15 @@ contract StrategyTest is StrategyFixture {
     using SafeERC20 for IERC20;
 
     IERC20 want;
+    IERC20 weth;
 
     // NOTE: feel free change these vars to adjust for your strategy testing
     IERC20 public immutable DAI = IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
+    IERC20 public immutable WETH = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     address public whale = 0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643;
     address public user = address(1337);
     address public user2 = address(7331);
+    uint256 WETH_AMT = 10 ** 18;
 
     // setup is run on before each test
     function setUp() public override {
@@ -26,6 +29,7 @@ contract StrategyTest is StrategyFixture {
 
         // replace with your token
         want = DAI;
+        weth = WETH;
 
         deployVaultAndStrategy(
             address(want),
@@ -40,7 +44,8 @@ contract StrategyTest is StrategyFixture {
 
         // do here additional setup
         vault.setDepositLimit(type(uint256).max);
-        tip(address(want), address(this), 10000e18);
+        tip(address(want), address(user), 10000e18);
+        vm_std_cheats.deal(user, 10_000 ether);
     }
 
     function testSetupVaultOK() public {
@@ -50,7 +55,7 @@ contract StrategyTest is StrategyFixture {
         assertEq(vault.depositLimit(), type(uint256).max);
     }
 
-    // TODO: add additiona check on strat params
+    // TODO: add additional check on strat params
     function testSetupStrategyOK() public {
         console.log("address of strategy", address(strategy));
         assertTrue(address(0) != address(strategy));
@@ -60,22 +65,148 @@ contract StrategyTest is StrategyFixture {
     function testStrategyOperation(uint256 _amount) public {
         vm_std_cheats.assume(_amount > 0.1 ether && _amount < 10e18);
 
-        uint balanceBefore = want.balanceOf(address(this));
+        uint256 balanceBefore = want.balanceOf(address(user));
+        vm_std_cheats.prank(user);
         want.approve(address(vault), _amount);
+        vm_std_cheats.prank(user);
         vault.deposit(_amount);
         assertEq(want.balanceOf(address(vault)), _amount);
 
-        
+
         // Note: need to check if this is equivalent to chain.sleep in brownie
         skip(60 * 3); // skip 3 minutes
         // harvest
         strategy.harvest();
         assertEq(strategy.estimatedTotalAssets(), _amount);
         // tend
-        strategy.tend();      
+        strategy.tend();
 
+        vm_std_cheats.prank(user);
         vault.withdraw();
 
-        assertEq(want.balanceOf(address(this)), balanceBefore);  
+        assertEq(want.balanceOf(user), balanceBefore);
+    }
+
+    function testEmergencyExit(uint256 _amount) public {
+        vm_std_cheats.assume(_amount > 0.1 ether && _amount < 10e18);
+
+        // Deposit to the vault
+        vm_std_cheats.prank(user);
+        want.approve(address(vault), _amount);
+        vm_std_cheats.prank(user);
+        vault.deposit(_amount);
+        skip(1);
+        strategy.harvest();
+        assertEq(strategy.estimatedTotalAssets(), _amount);
+
+        // set emergency and exit
+        strategy.setEmergencyExit();
+        skip(1);
+        strategy.harvest();
+        assertLt(strategy.estimatedTotalAssets(), _amount);
+    }
+
+    function testProfitableHarvest(uint256 _amount) public {
+        vm_std_cheats.assume(_amount > 0.1 ether && _amount < 10e18);
+
+        // Deposit to the vault
+        vm_std_cheats.prank(user);
+        want.approve(address(vault), _amount);
+        vm_std_cheats.prank(user);
+        vault.deposit(_amount);
+        assertEq(want.balanceOf(address(vault)), _amount);
+
+        // Harvest 1: Send funds through the strategy
+        skip(1);
+        strategy.harvest();
+        assertEq(strategy.estimatedTotalAssets(), _amount);
+
+        // TODO: Add some code before harvest #2 to simulate earning yield
+
+        // Harvest 2: Realize profit
+        skip(1);
+        strategy.harvest();
+        skip(3600 * 6);
+        uint256 profit = want.balanceOf(address(vault));
+        // TODO: Uncomment the lines below
+        // assertGt(want.balanceOf(address(strategy) + profit), _amount);
+        // assertGt(vault.pricePerShare(), beforePps)
+    }
+
+    function testChangeDebt(uint256 _amount) public {
+        vm_std_cheats.assume(_amount > 0.1 ether && _amount < 10e18);
+
+        // Deposit to the vault and harvest
+        vm_std_cheats.prank(user);
+        want.approve(address(vault), _amount);
+        vm_std_cheats.prank(user);
+        vault.deposit(_amount);
+        vault.updateStrategyDebtRatio(address(strategy), 5_000);
+        skip(1);
+        strategy.harvest();
+        uint256 half = uint256(_amount / 2);
+        assertEq(strategy.estimatedTotalAssets(), half);
+
+        vault.updateStrategyDebtRatio(address(strategy), 10_000);
+        skip(1);
+        strategy.harvest();
+        assertEq(strategy.estimatedTotalAssets(), _amount);
+
+        // In order to pass these tests, you will need to implement prepareReturn.
+        // TODO: uncomment the following lines.
+        // vault.updateStrategyDebtRatio(address(strategy), 5_000);
+        // skip(1);
+        // strategy.harvest();
+        // assertEq(strategy.estimatedTotalAssets(), half);
+    }
+
+    function testSweep(uint256 _amount) public {
+        vm_std_cheats.assume(_amount > 0.1 ether && _amount < 10e18);
+
+        vm_std_cheats.prank(user);
+        (bool sent, ) = address(weth).call{value: WETH_AMT}("");
+        require(sent, "failed to send ether");
+
+        // Strategy want token doesn't work
+        vm_std_cheats.prank(user);
+        want.transfer(address(strategy), _amount);
+        assertEq(address(want), address(strategy.want()));
+        assertGt(want.balanceOf(address(strategy)), 0);
+
+        vm_std_cheats.expectRevert("!want");
+        strategy.sweep(address(want));
+
+        // Vault share token doesn't work
+        vm_std_cheats.expectRevert("!shares");
+        strategy.sweep(address(vault));
+
+        // TODO: If you add protected tokens to the strategy.
+        // Protected token doesn't work
+        // vm_std_cheats.expectRevert("!protected");
+        // strategy.sweep(strategy.protectedToken());
+
+        uint256 beforeBalance = weth.balanceOf(address(this));
+        vm_std_cheats.prank(user);
+        weth.transfer(address(strategy), WETH_AMT);
+        assertNeq(address(weth), address(strategy.want()));
+        assertEq(weth.balanceOf(address(user)), 0);
+        strategy.sweep(address(weth));
+        assertEq(weth.balanceOf(address(this)), WETH_AMT + beforeBalance);
+    }
+
+    function testTriggers(uint256 _amount) public {
+        vm_std_cheats.assume(_amount > 0.1 ether && _amount < 10e18);
+
+        // Deposit to the vault and harvest
+        vm_std_cheats.prank(user);
+        want.approve(address(vault), _amount);
+        vm_std_cheats.prank(user);
+        vault.deposit(_amount);
+        vault.updateStrategyDebtRatio(address(strategy), 5_000);
+        skip(1);
+        strategy.harvest();
+
+        strategy.harvestTrigger(0);
+        strategy.tendTrigger(0);
     }
 }

--- a/src/test/utils/ExtendedDSTest.sol
+++ b/src/test/utils/ExtendedDSTest.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0
+import "ds-test/test.sol";
+
+contract ExtendedDSTest is DSTest {
+    function assertNeq(address a, address b) internal {
+        if (a == b) {
+            emit log("Error: a != b not satisfied [address]");
+            emit log_named_address("  Expected", b);
+            emit log_named_address("    Actual", a);
+            fail();
+        }
+    }
+}

--- a/src/test/utils/Test.sol
+++ b/src/test/utils/Test.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.12;
 pragma abicoder v2;
 
-import "ds-test/test.sol";
+import {ExtendedDSTest} from "./ExtendedDSTest.sol";
 import {stdCheats} from "forge-std/stdlib.sol";
 import {IVault} from "../../interface/Vault.sol";
 
@@ -14,7 +14,7 @@ import {Strategy} from "../../Strategy.sol";
 string constant vaultArtifact = 'artifacts/Vault.json';
 
 // Base fixture deploying Vault
-contract StrategyFixture is DSTest, stdCheats {
+contract StrategyFixture is ExtendedDSTest, stdCheats {
     IVault public vault;
     Strategy public strategy;
 
@@ -93,5 +93,5 @@ contract StrategyFixture is DSTest, stdCheats {
             1_000
         );
     }
-    
+
 }


### PR DESCRIPTION
Ported operations tests across from brownie-strategy-mix.

Things worth noting: 
- `updateStrategyDebtRatio` was missing from Vault interface. 
- foundry has no equivalent for `Contracts.at`, so I coerced WETH9 to IERC20 even though technically it doesn't inherit from it. 
- let gov to be the deploying contract (i.e. `address(this)`) and used the `user` to represent a user. 

Also, as far as I can tell, `skip` does work similar to brownie's `chain.sleep`.

If this is okay, I am happy to work on the other ones too. 