### PR TITLE
test: add shutdown tests

### DIFF
--- a/src/interface/Vault.sol
+++ b/src/interface/Vault.sol
@@ -134,6 +134,8 @@ interface IVault is IERC20 {
 
     function migrateStrategy(address oldVersion, address newVersion) external;
 
+    function setEmergencyShutdown(bool active) external;
+
     function updateStrategyDebtRatio(address strategy, uint256 debtRatio)
         external;
 

--- a/src/test/StrategyShutdown.t.sol
+++ b/src/test/StrategyShutdown.t.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.12;
+
+import {StrategyFixture} from "./utils/StrategyFixture.sol";
+
+contract StrategyShutdownTest is StrategyFixture {
+    function setUp() public override {
+        super.setUp();
+    }
+
+    function testVaultShutdownCanWithdraw(uint256 _amount) public {
+        vm_std_cheats.assume(_amount > 0.1 ether && _amount < 10e18);
+
+        // Deposit to the vault
+        vm_std_cheats.prank(user);
+        want.approve(address(vault), _amount);
+        vm_std_cheats.prank(user);
+        vault.deposit(_amount);
+        assertEq(want.balanceOf(address(vault)), _amount);
+
+        uint256 bal = want.balanceOf(user);
+        if (bal > 0) {
+            vm_std_cheats.prank(user);
+            want.transfer(address(0), bal);
+        }
+
+        // Harvest 1: Send funds through the strategy
+        skip(3600 * 7);
+        vm_std_cheats.roll(block.number + 1);
+        strategy.harvest();
+        assertEq(strategy.estimatedTotalAssets(), _amount);
+
+        // Set Emergency
+        vault.setEmergencyShutdown(true);
+
+        // Withdraw (does it work, do you get what you expect)
+        vm_std_cheats.prank(user);
+        vault.withdraw();
+
+        assertEq(want.balanceOf(user), _amount);
+    }
+
+    function testBasicShutdown(uint256 _amount) public {
+        vm_std_cheats.assume(_amount > 0.1 ether && _amount < 10e18);
+
+        // Deposit to the vault
+        vm_std_cheats.prank(user);
+        want.approve(address(vault), _amount);
+        vm_std_cheats.prank(user);
+        vault.deposit(_amount);
+        assertEq(want.balanceOf(address(vault)), _amount);
+
+        // Harvest 1: Send funds through the strategy
+        skip(1 days);
+        vm_std_cheats.roll(block.number + 100);
+        strategy.harvest();
+        assertEq(strategy.estimatedTotalAssets(), _amount);
+
+        // Earn interest
+        skip(1 days);
+        vm_std_cheats.roll(block.number + 1);
+
+        // Harvest 2: Realize profit
+        strategy.harvest();
+        skip(6 hours);
+        vm_std_cheats.roll(block.number + 1);
+
+        // Set emergency
+        vm_std_cheats.prank(strategist);
+        strategy.setEmergencyExit();
+
+        strategy.harvest(); // Remove funds from strategy
+
+        assertEq(want.balanceOf(address(strategy)), 0);
+        assertGe(want.balanceOf(address(vault)), _amount); // The vault has all funds
+        // NOTE: May want to tweak this based on potential loss during migration
+    }
+}


### PR DESCRIPTION
Added shutdown tests.

Encountered an issue when porting the code across from brownie where the brownie tests would call `harvest()` before any time has passed. It doesn't work here in foundry, so I had to re-order the time skips to that they took place before the `harvest()` occurs, which is consistent with all the other test cases. The only thing that confuses me is that I don't understand why this test passes in the brownie repo. 

brownie:
https://github.com/yearn/brownie-strategy-mix/blob/a3372202c8107e626fef4a73703279a50fa8fae8/tests/test_shutdown.py#L19-L23

foundry:
https://github.com/storming0x/foundry_strategy_mix/blob/17f1214374837d982d11395863a4f3405f6c6ecc/src/test/StrategyOperation.t.sol#L39-L43

closes #1 