### PR TITLE
feat: make fuzzing amt variable to support different tokens

### DIFF
--- a/src/test/StrategyMigration.t.sol
+++ b/src/test/StrategyMigration.t.sol
@@ -15,9 +15,7 @@ contract StrategyMigrationTest is StrategyFixture {
     // Use another copy of the strategy to simmulate the migration
     // Show that nothing is lost.
     function testMigration(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), user, _amount);
 
         // Deposit to the vault and harvest

--- a/src/test/StrategyOperation.t.sol
+++ b/src/test/StrategyOperation.t.sol
@@ -27,9 +27,7 @@ contract StrategyOperationsTest is StrategyFixture {
 
     /// Test Operations
     function testStrategyOperation(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), user, _amount);
 
         uint256 balanceBefore = want.balanceOf(address(user));
@@ -55,9 +53,7 @@ contract StrategyOperationsTest is StrategyFixture {
     }
 
     function testEmergencyExit(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), user, _amount);
 
         // Deposit to the vault
@@ -80,9 +76,7 @@ contract StrategyOperationsTest is StrategyFixture {
     }
 
     function testProfitableHarvest(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), user, _amount);
 
         // Deposit to the vault
@@ -115,9 +109,7 @@ contract StrategyOperationsTest is StrategyFixture {
     }
 
     function testChangeDebt(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), user, _amount);
 
         // Deposit to the vault and harvest
@@ -151,9 +143,7 @@ contract StrategyOperationsTest is StrategyFixture {
     }
 
     function testSweep(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), user, _amount);
 
         // Strategy want token doesn't work
@@ -194,9 +184,7 @@ contract StrategyOperationsTest is StrategyFixture {
     }
 
     function testTriggers(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), user, _amount);
 
         // Deposit to the vault and harvest

--- a/src/test/StrategyRevoke.t.sol
+++ b/src/test/StrategyRevoke.t.sol
@@ -9,9 +9,7 @@ contract StrategyRevokeTest is StrategyFixture {
     }
 
     function testRevokeStrategyFromVault(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), user, _amount);
 
         // Deposit to the vault and harvest
@@ -35,9 +33,7 @@ contract StrategyRevokeTest is StrategyFixture {
     }
 
     function testRevokeStrategyFromStrategy(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), user, _amount);
 
         vm_std_cheats.prank(user);

--- a/src/test/StrategyShutdown.t.sol
+++ b/src/test/StrategyShutdown.t.sol
@@ -9,9 +9,7 @@ contract StrategyShutdownTest is StrategyFixture {
     }
 
     function testVaultShutdownCanWithdraw(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), user, _amount);
 
         // Deposit to the vault
@@ -45,9 +43,7 @@ contract StrategyShutdownTest is StrategyFixture {
     }
 
     function testBasicShutdown(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), user, _amount);
 
         // Deposit to the vault


### PR DESCRIPTION
Fuzzing amounts are now variables that can be controlled from within StrategyFixture. This allows you to use whichever token you want and allows you to set a price to reflect the state of the market. 