### PR TITLE
Small updates to test fixture and some usability additions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,12 @@ update:; forge update
 
 # Build & test
 # change ETH_RPC_URL to another one (e.g., FTM_RPC_URL) for different chains
+FORK_URL := ${ETH_RPC_URL} 
 build  :; forge build
-test   :; forge test -vv --fork-url ${ETH_RPC_URL} 
-trace   :; forge test -vvv --fork-url ${ETH_RPC_URL}
+test   :; forge test -vv --fork-url ${FORK_URL}
+trace   :; forge test -vvv --fork-url ${FORK_URL}
+test-contract :; forge test -vv --fork-url ${FORK_URL} --match-contract $(contract)
+trace-contract :; forge test -vvv --fork-url ${FORK_URL} --match-contract $(contract)
 # local tests without fork
 test-local  :; forge test
 trace-local  :; forge test -vvv

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Alice can then redeem those shares using `Vault.withdrawAll()` for the correspon
 git clone --recursive https://github.com/myuser/foundry-yearn-strategy
 
 cd foundry-yearn-strategy
-
 ```
 
 NOTE: if you create from template you may need to run the following command to fetch the git submodules (.gitmodules for exact releases) `git submodule init && git submodule update`
@@ -53,16 +52,8 @@ NOTE: you can use other services.
      NOTE: If you set up a global environment variable, that will take precedence
 
 7. Run tests
-
-NOTE: tests run in fork environment, you need to setup step 6 to be able to run these commands.
-
 ```sh
 make test
-```
-Run tests with traces (very useful)
-
-```sh
-make trace
 ```
 
 ## Basic Use
@@ -86,19 +77,28 @@ TODO
 
 ## Testing
 
-To run the tests:
+Tests run in fork environment, you need to complete [Installation and Setup](#installation-and-setup) step 6 to be able to run these commands.
 
-```
+```sh
 make test
 ```
+Run tests with traces (very useful)
 
-to run tests with traces (using console.sol):
-
-```
+```sh
 make trace
 ```
+Run specific test contract (e.g. `test/StrategyOperation.t.sol`)
 
-See here for some tips on testing [`Testing Tips`](docs/testing_tips_coming_from_brownie.md)
+```sh
+make test-contract contract=StrategyOperationsTest
+```
+Run specific test contract with traces (e.g. `test/StrategyOperation.t.sol`)
+
+```sh
+make trace-contract contract=StrategyOperationsTest
+```
+
+See here for some tips on testing [`Testing Tips`](https://book.getfoundry.sh/forge/tests.html)
 
 # Resources
 
@@ -106,6 +106,6 @@ See here for some tips on testing [`Testing Tips`](docs/testing_tips_coming_from
 - [Getting help on Foundry](https://github.com/gakonst/foundry#getting-help)
 - [Forge Standard Lib](https://github.com/brockelmore/forge-std)
 - [Awesome Foundry](https://github.com/crisgarner/awesome-foundry)
-- [Foundry Book](https://onbjerg.github.io/foundry-book/index.html)
+- [Foundry Book](https://book.getfoundry.sh/)
 - [Learn Foundry Tutorial](https://www.youtube.com/watch?v=Rp_V7bYiTCM)
 

--- a/src/test/StrategyOperation.t.sol
+++ b/src/test/StrategyOperation.t.sol
@@ -37,11 +37,11 @@ contract StrategyOperationsTest is StrategyFixture {
         vault.deposit(_amount);
         assertRelApproxEq(want.balanceOf(address(vault)), _amount, DELTA);
 
-        // Note: need to check if this is equivalent to chain.sleep in brownie
-        skip(60 * 3); // skip 3 minutes
+        skip(3 minutes);
         vm_std_cheats.prank(strategist);
         strategy.harvest();
         assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+
         // tend
         vm_std_cheats.prank(strategist);
         strategy.tend();
@@ -100,7 +100,7 @@ contract StrategyOperationsTest is StrategyFixture {
         skip(1);
         vm_std_cheats.prank(strategist);
         strategy.harvest();
-        skip(3600 * 6);
+        skip(6 hours);
 
         // TODO: Uncomment the lines below
         // uint256 profit = want.balanceOf(address(vault));

--- a/src/test/StrategyShutdown.t.sol
+++ b/src/test/StrategyShutdown.t.sol
@@ -26,7 +26,7 @@ contract StrategyShutdownTest is StrategyFixture {
         }
 
         // Harvest 1: Send funds through the strategy
-        skip(3600 * 7);
+        skip(7 hours);
         vm_std_cheats.prank(strategist);
         strategy.harvest();
         assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);


### PR DESCRIPTION
StrategyFixture
- Enforced `deploy...` functions to not set fixture state, rather `setUp` is responsible for this

Tests
- Use sol `minutes` etc syntax when calling skip

Makefile
- Add commands to test a specific contract (useful if test suite is large)
