### PR TITLE
feat: add etherscan support for better traces while testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ ARBI_RPC_URL=https://arb1.arbitrum.io/rpc
 GC_RPC_URL=https://xdai.poanetwork.dev
 BSC_RPC_URL=https://bsc-dataseed.binance.org
 MATIC_RPC_URL=
+ETHERSCAN_API_KEY=

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,4 +24,5 @@ jobs:
       - name: Run tests
         env:
           ETH_RPC_URL: https://mainnet.infura.io/v3/b7821200399e4be2b4e5dbdf06fbe85b
+          ETHERSCAN_API_KEY: 6776WKCX4XHV7C6NQBTIME6XKM2YNBK29V
         run: make trace

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ update:; forge update
 # Build & test
 # change ETH_RPC_URL to another one (e.g., FTM_RPC_URL) for different chains
 build  :; forge build
-test   :; forge test -vv --fork-url ${ETH_RPC_URL} 
-trace   :; forge test -vvv --fork-url ${ETH_RPC_URL}
+test   :; ETHERSCAN_API_KEY=${ETHERSCAN_API_KEY} forge test -vv --fork-url ${ETH_RPC_URL}
+trace   :; ETHERSCAN_API_KEY=${ETHERSCAN_API_KEY} forge test -vvv --fork-url ${ETH_RPC_URL}
 # local tests without fork
 test-local  :; forge test
 trace-local  :; forge test -vvv

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ update:; forge update
 # Build & test
 # change ETH_RPC_URL to another one (e.g., FTM_RPC_URL) for different chains
 build  :; forge build
-test   :; ETHERSCAN_API_KEY=${ETHERSCAN_API_KEY} forge test -vv --fork-url ${ETH_RPC_URL}
-trace   :; ETHERSCAN_API_KEY=${ETHERSCAN_API_KEY} forge test -vvv --fork-url ${ETH_RPC_URL}
+test   :; forge test -vv --fork-url ${ETH_RPC_URL} --etherscan-api-key ${ETHERSCAN_API_KEY}
+trace   :; forge test -vvv --fork-url ${ETH_RPC_URL} --etherscan-api-key ${ETHERSCAN_API_KEY}
 # local tests without fork
 test-local  :; forge test
 trace-local  :; forge test -vvv

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ NOTE: you can use other services.
 
 6. Use .env file
   1. Make a copy of `.env.example`
-  2. Add the values for `ETH_RPC_URL` and other example vars
-     NOTE: If you set up a global environment variable, that will take precedence
+  2. Add the values for `ETH_RPC_URL`, `ETHERSCAN_API_KEY` and other example vars
+     NOTE: If you set up a global environment variable, that will take precedence.
 
 7. Run tests
 


### PR DESCRIPTION
Add `ETHERSCAN_API_KEY` env variable for better traces while testing.

Took the etherscan_api_key from [here](https://github.com/yearn/yearn-protocol/blob/a22eb5b88cec7698b75d9ea0db02f19b5e6e009b/.github/workflows/test.yaml).