### PR TITLE
Issue #2 Deploy and Verification script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ GC_RPC_URL=https://xdai.poanetwork.dev
 BSC_RPC_URL=https://bsc-dataseed.binance.org
 MATIC_RPC_URL=
 ETHERSCAN_API_KEY=
+PRIV_KEY=

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ FORK_URL := ${ETH_RPC_URL}
 
 # For deployments. Add all args without a comma
 # ex: 0x316..FB5 "Name" 10
-constructor-args := 0x31676A29E0B17529f9503C6E5673A8dA56ec2FB5
+constructor-args := 
 
 build  :; forge build
 test   :; forge test -vv --fork-url ${FORK_URL} --etherscan-api-key ${ETHERSCAN_API_KEY}

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,17 @@ update:; forge update
 # Build & test
 # change ETH_RPC_URL to another one (e.g., FTM_RPC_URL) for different chains
 FORK_URL := ${ETH_RPC_URL} 
+
+# For deployments. Add all args without a comma
+# ex: 0x316..FB5 "Name" 10
+constructor-args := 0x31676A29E0B17529f9503C6E5673A8dA56ec2FB5
+
 build  :; forge build
 test   :; forge test -vv --fork-url ${FORK_URL} --etherscan-api-key ${ETHERSCAN_API_KEY}
 trace   :; forge test -vvv --fork-url ${FORK_URL} --etherscan-api-key ${ETHERSCAN_API_KEY}
 test-contract :; forge test -vv --fork-url ${FORK_URL} --match-contract $(contract) --etherscan-api-key ${ETHERSCAN_API_KEY}
 trace-contract :; forge test -vvv --fork-url ${FORK_URL} --match-contract $(contract) --etherscan-api-key ${ETHERSCAN_API_KEY}
+deploy	:; forge create --rpc-url ${FORK_URL} --constructor-args ${constructor-args} --private-key ${PRIV_KEY} src/Strategy.sol:Strategy --etherscan-api-key ${ETHERSCAN_API_KEY} --verify
 # local tests without fork
 test-local  :; forge test
 trace-local  :; forge test -vvv

--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ See here for some tips on testing [`Testing Tips`](https://book.getfoundry.sh/fo
 
 You can Deploy and verify your strategies if PRIV_KEY and ETHERSCAN_API_KEY are both set in the .env by using the command
 
-'''sh
+```sh
 make deploy
-'''
+```
 
-Before deploying update the constructor-args variable to include any parameters needed. Make sure to seperate each argument only by a space, no commas.
+Before deploying, update the constructor-args variable within the Makefile to include any parameters applicable. Make sure to seperate each argument only by a space, no commas.
 
 The deploy script is coded to deploy the "Strategy" contract within the Strategy.sol file. This can be updated by simply updating to src/YourContract.sol:YourContract.
 # Resources

--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ make trace-contract contract=StrategyOperationsTest
 
 See here for some tips on testing [`Testing Tips`](https://book.getfoundry.sh/forge/tests.html)
 
+## Deploying Contracts
+
+You can Deploy and verify your strategies if PRIV_KEY and ETHERSCAN_API_KEY are both set in the .env by using the command
+
+'''sh
+make deploy
+'''
+
+Before deploying update the constructor-args variable to include any parameters needed. Make sure to seperate each argument only by a space, no commas.
+
+The deploy script is coded to deploy the "Strategy" contract within the Strategy.sol file. This can be updated by simply updating to src/YourContract.sol:YourContract.
 # Resources
 
 - Yearn [Discord channel](https://discord.com/invite/6PNv2nF/)


### PR DESCRIPTION
Deploy command added to Make file for deployment and verification of a strategy. Instructions added to the Readme as well

Constructor args need to be set in the make file before deployment and the contract to deploy is defaulted to Strategy.sol:Strategy